### PR TITLE
Add documentation bade to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FlyWithPython - New Python Interface for X-Plane
 
+
+[![Documentation Status](https://readthedocs.org/projects/flywithpython/badge/?version=latest)](https://flywithpython.readthedocs.io/?badge=latest)
 [![Join the chat at https://gitter.im/stormrose-va/FlyWithPython](https://badges.gitter.im/stormrose-va/FlyWithPython.svg)](https://gitter.im/stormrose-va/FlyWithPython?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This project repository contains all code of FlyWithPython, a new Python


### PR DESCRIPTION
### Summary

Add documentation badge to README

### Benefits

Link to documentation available on repo's front page

### Drawbacks and Risks

None

### Alternate Designs

None

### Applicable Issues

Fix #3 
